### PR TITLE
Deprecated class constructor

### DIFF
--- a/yubicloud.class.php
+++ b/yubicloud.class.php
@@ -118,7 +118,7 @@ class Yubicloud
 	const YUBICO_MODHEX_CHARS = "cbdefghijklnrtuv"; // ModHex values (instead of 01234567890abcdef)
 
 
-    function Yubicloud($yubicloud_client_id = 1, $yubicloud_secret_key = '', $yubicloud_https = false)
+    function __construct($yubicloud_client_id = 1, $yubicloud_secret_key = '', $yubicloud_https = false)
     /**
      * @brief   Class constructor.
      *


### PR DESCRIPTION
PHP7 treats a function with the same name as the class as deprecated, therefore the function is renamed to __construct, to make it up to date.